### PR TITLE
Allow to bind on a specific address

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,10 +14,10 @@ const (
 
 var Version string
 var RootCmd = &cobra.Command{
-	Use:   "ipsec_exporter",
-	Short: "Prometheus exporter for ipsec status.",
-	Long:  "",
-	Run:   defaultCommand,
+	Use:     "ipsec_exporter",
+	Short:   "Prometheus exporter for ipsec status.",
+	Long:    "",
+	Run:     defaultCommand,
 	Version: Version,
 }
 
@@ -26,8 +26,8 @@ func init() {
 		"/etc/ipsec.conf",
 		"Path to the ipsec config file.")
 
-	RootCmd.PersistentFlags().IntVar(&exporter.WebListenAddress, flagWebListenAddress,
-		9536,
+	RootCmd.PersistentFlags().StringVar(&exporter.WebListenAddress, flagWebListenAddress,
+		":9536",
 		"Address on which to expose metrics.")
 }
 

--- a/exporter/serve.go
+++ b/exporter/serve.go
@@ -6,11 +6,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/log"
 	"net/http"
-	"strconv"
 )
 
 var IpSecConfigFile string
-var WebListenAddress int
+var WebListenAddress string
 
 var ipSecConfiguration *ipsec.Configuration
 
@@ -40,7 +39,7 @@ func Serve() {
 	http.Handle("/metrics", promhttp.Handler())
 
 	log.Infoln("Listening on", WebListenAddress)
-	err = http.ListenAndServe(":"+strconv.Itoa(WebListenAddress), nil)
+	err = http.ListenAndServe(WebListenAddress, nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
In some contexts it's handy to listen only on a certain address (e.g. 127.0.0.1). This PR makes `web.listen-address` a string, which is inline with [other](https://github.com/prometheus/statsd_exporter/blob/master/main.go#L142) [exporters](https://github.com/prometheus/node_exporter/blob/master/node_exporter.go#L141).